### PR TITLE
Update to support Cake4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,13 @@
     },
     "require": {
         "php": ">=5.4",
-        "cakephp/cache": "^3.0",
+        "cakephp/cache": "^4.0",
         "predis/predis": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8"
+    },
+    "scripts": {
+        "test": "./vendor/bin/phpunit"
     }
 }

--- a/tests/PredisEngineTest.php
+++ b/tests/PredisEngineTest.php
@@ -28,11 +28,11 @@ final class PredisEngineTest extends \PHPUnit_Framework_TestCase
      */
     public function testWriteAndReadDataTypesAndThenDelete($value)
     {
-        $this->assertTrue($this->engine->write('dataType', $value));
-        $this->assertEquals($value, $this->engine->read('dataType'));
+        $this->assertTrue($this->engine->set('dataType', $value));
+        $this->assertEquals($value, $this->engine->get('dataType'));
 
         $this->assertTrue($this->engine->delete('dataType'));
-        $this->assertFalse($this->engine->read('dataType'));
+        $this->assertFalse($this->engine->get('dataType', false));
     }
 
     public function writeAndReadDataTypes()
@@ -51,7 +51,7 @@ final class PredisEngineTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertFalse($this->engine->increment('key'));
 
-        $this->assertTrue($this->engine->write('key', 10));
+        $this->assertTrue($this->engine->set('key', 10));
         $this->assertEquals(11, $this->engine->increment('key'));
         $this->assertEquals(12, $this->engine->increment('key'));
         $this->assertEquals(13, $this->engine->increment('key'));
@@ -61,7 +61,7 @@ final class PredisEngineTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertFalse($this->engine->decrement('key'));
 
-        $this->assertTrue($this->engine->write('key', 10));
+        $this->assertTrue($this->engine->set('key', 10));
         $this->assertEquals(9, $this->engine->decrement('key'));
         $this->assertEquals(8, $this->engine->decrement('key'));
         $this->assertEquals(7, $this->engine->decrement('key'));


### PR DESCRIPTION
This PR updates the library to support Cake4.

Cake4 updates the interface for CacheEngine and changes `read`/`write` to `get`/`set` and allows more flexibility with specifying defaults.

The new interface also adds `clearGroup` (`public function clearGroup(string $group): bool`). I implemented `clearGroup` using the naive method of just iterating over `keys ...` from redis. The CakePHP `RedisEngine` implements this by keeping a separate key for groups and incrementing it when clearing a group. I didn't see an easy way to do this without rewriting much of this engine, so I chose to keep the naive approach for now.